### PR TITLE
Upgrade to net8

### DIFF
--- a/.github/workflows/liara-deploy.yml
+++ b/.github/workflows/liara-deploy.yml
@@ -1,6 +1,6 @@
 name: Shortener
 env:
-  DOTNET_VERSION: '7'
+  DOTNET_VERSION: '8'
 'on':
   pull_request:
     branches:

--- a/src/Shortener/Shortener.csproj
+++ b/src/Shortener/Shortener.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>f6a4abc2-71ea-42d6-8b39-4a0059030a5c</UserSecretsId>
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.17" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.18" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.6" />
-    <PackageReference Include="MongoDB.EntityFrameworkCore" Version="7.0.0-preview.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
+    <PackageReference Include="MongoDB.EntityFrameworkCore" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/tests/Shortener.UnitTests/Shortener.UnitTests.csproj
+++ b/tests/Shortener.UnitTests/Shortener.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,11 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="3.2.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.7.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="xunit" Version="2.8.0" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.8.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Title:** Update Target Framework and Package Versions

**Description:**
This pull request aims to modernize the project dependencies by updating target frameworks and package versions in both the `Shortener.csproj` and `Shortener.UnitTests.csproj` files.

**Changes in Shortener.csproj:**
- Updated `<TargetFramework>` from `net7.0` to `net8.0`.
- Updated package references:
  - `Microsoft.AspNetCore.OpenApi` from version `7.0.17` to `8.0.4`.
  - `Microsoft.EntityFrameworkCore` from version `7.0.18` to `8.0.4`.
  - `Microsoft.Extensions.Caching.Memory` from version `7.0.0` to `8.0.0`.
  - `Microsoft.VisualStudio.Azure.Containers.Tools.Targets` from version `1.19.6` to `1.20.1`.
  - `MongoDB.EntityFrameworkCore` from version `7.0.0-preview.1` to `8.0.0`.

**Changes in Shortener.UnitTests.csproj:**
- Updated `<TargetFramework>` from `net7.0` to `net8.0`.
- Updated package references:
  - `coverlet.collector` from version `3.2.0` to `6.0.2`.
  - `Microsoft.NET.Test.Sdk` from version `17.7.1` to `17.9.0`.
  - `xunit` from version `2.4.2` to `2.8.0`.
  - `xunit.extensibility.core` from version `2.7.1` to `2.8.0`.
  - `xunit.runner.visualstudio` from version `2.4.5` to `2.8.0`.

**Changes in liara-deploy.yml:**
- Updated `DOTNET_VERSION` from `'7'` to `'8'`

**Rationale:**
These updates are essential for maintaining compatibility with the latest .NET technologies and ensuring that the project remains up-to-date with the latest features, performance improvements, and security patches provided by the updated dependencies.
